### PR TITLE
5GHz Kanal von 44 auf 100 geaendert

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -21,7 +21,7 @@
 	},
 	wifi5 => {
 		ssid => 'hamburg.freifunk.net (5GHz)',
-		channel => 44,
+		channel => 100,
 		htmode => 'HT40+',
 		mesh_ssid => 'f8:d1:11:87:52:2e',
 		mesh_bssid => 'f8:d1:11:87:52:2e',


### PR DESCRIPTION
Kanal 100 darf sowohl drinnen alas auch draussen genutzt werden.
