### PR TITLE
Remove lede opkg mirror

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -12,7 +12,6 @@
 	default_domain = 'ffhh_nowe',
 
 	opkg = {
-		lede = 'http://lede.opkg.services.ffhh/snapshots/packages/%A',
 		extra = {
 			modules = 'http://updates.hamburg.freifunk.net/multi/archive/%GR/packages/gluon-%GS-%GR/%S',
 		},


### PR DESCRIPTION
In v2018.2.x Gluon switched from Lede back to OpenWrt including the opkg site config.

https://gluon.readthedocs.io/en/v2018.2.x/user/site.html

I am not sure if the backend mirror is already the same for Lede and OpenWrt. (maybe the url requires a change accordingly)

The line `lede` could also be removed, `openwrt` is not required if the nodes have a IPv6 internet connectivity. And that seems to be the case, the site-ffhh release v2018.2.1.0 uses the default mirror `http://downloads.openwrt.org/snapshots/packages/%A` as `openwrt =` is unset.